### PR TITLE
fix: cast unknown to any before destructuring

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,7 +202,7 @@ export function commonjs({
         try {
           ({ warnings } = await require_esbuild().transform(contents, { format: "esm", logLevel: "silent" }));
         } catch (err) {
-          ({ warnings } = err);
+          ({ warnings } = err as any);
         }
 
         let lines = contents.split("\n");


### PR DESCRIPTION
Accessing a property of error causes an error, as it is typed as unknown. 

A [minimal reproduction of the type problem can be found here](https://www.typescriptlang.org/play?ts=4.4.4#code/MYewdgzgLgBAZmGBeGAKAlMgfDA3jKACwCcQB3GMAUwoFFjTiMYBfAbgCgOAbK2MgIbEwASzABzCAC4Y0YmPEBtALqcuUYgE88HGGnyDhCiK2TwwGdJxYxgAqMEJoqDTLl36Yh0RJM2ULsRWHCxAA), and [more details about how and why this was changed is here. 
](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables)

Casting this to an any solved the problem.


